### PR TITLE
Fix top level links to Sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 The aim here is to curate a (mostly) comprehensive list of available tools for verifying
 the functional correctness of Free and Open Source Hardware designs. The list can
 include:
-- [Tools](#Tools) which contain or implement verification related functionality
-- [Testbench Frameworks](#Frameworks) which make writing testbenches easier
-- [Projects](#Projects) which are good examples of free/open hardware verification efforts
-- [Verification Guides](#Guides) and blog posts on how to actually go about verifying a hardware design
-- [Conferences](#Conferences) where new work on open source hardware verification is talked about
+- [Tools](#tools) which contain or implement verification related functionality
+- [Testbench Frameworks](#frameworks) which make writing testbenches easier
+- [Projects](#projects) which are good examples of free/open hardware verification efforts
+- [Verification Guides](#guides) and blog posts on how to actually go about verifying a hardware design
+- [Conferences](#conferences) where new work on open source hardware verification is talked about
 
 Pull requests and submissions are encouraged!
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ include:
 - [Tools](#tools) which contain or implement verification related functionality
 - [Testbench Frameworks](#testbench-frameworks) which make writing testbenches easier
 - [Projects](#projects) which are good examples of free/open hardware verification efforts
-- [Verification Guides](#guides-&-blogs) and blog posts on how to actually go about verifying a hardware design
+- [Verification Guides](#guides--blogs) and blog posts on how to actually go about verifying a hardware design
 - [Conferences](#conferences) where new work on open source hardware verification is talked about
 
 Pull requests and submissions are encouraged!

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The aim here is to curate a (mostly) comprehensive list of available tools for v
 the functional correctness of Free and Open Source Hardware designs. The list can
 include:
 - [Tools](#tools) which contain or implement verification related functionality
-- [Testbench Frameworks](#frameworks) which make writing testbenches easier
+- [Testbench Frameworks](#testbench-frameworks) which make writing testbenches easier
 - [Projects](#projects) which are good examples of free/open hardware verification efforts
 - [Verification Guides](#guides) and blog posts on how to actually go about verifying a hardware design
 - [Conferences](#conferences) where new work on open source hardware verification is talked about

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ include:
 - [Tools](#tools) which contain or implement verification related functionality
 - [Testbench Frameworks](#testbench-frameworks) which make writing testbenches easier
 - [Projects](#projects) which are good examples of free/open hardware verification efforts
-- [Verification Guides](#guides) and blog posts on how to actually go about verifying a hardware design
+- [Verification Guides](#guides-&-blogs) and blog posts on how to actually go about verifying a hardware design
 - [Conferences](#conferences) where new work on open source hardware verification is talked about
 
 Pull requests and submissions are encouraged!


### PR DESCRIPTION
Fixes links to the sections at the top of the README markdown file. Since these are the first links a new user finds, they should work!

### Changelist

- Fixed broken links -- `Tools` became `tools` for example.
- Changed the `Frameworks` and `Guides` links to point to the top level sections, rather than the individual entry sections.

### How has this been Tested

Working example is my forked repo on branch [dev.smattacus.fix.links](https://github.com/Smattacus/smattacus-fork-awesome-open-hardware-verification/tree/dev.smattacus.fix.links)

### Comments

As an aside, github now automatically creates a TOC for markdown files: https://github.blog/changelog/2021-04-13-table-of-contents-support-in-markdown-files/