### PR TITLE
Fix Icarus Verilog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Slower than Verilator, but it supports full 4-state simulation (i.e. X's and
 Z's).
 
 - Write testbenches in: Verilog, or use [cocotb](#cocotb).
-- Link: http://iverilog.icarus.com/
+- Link: https://github.com/steveicarus/iverilog
 
 ### LibreCores CI
 


### PR DESCRIPTION
Old icarus verilog site seems to be down.
Added link directly to repo as i could not find a new site. The repo also include the docs.